### PR TITLE
Retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ All ``<dataSource>`` parameters are optional
 
 - ``endpoint`` - AWS Dynamo Endpoint (expert)
 - ``region`` - Region name
+- ``maxErrorRetries`` - Default is 10, this is the maximum number or times to retry when the AWS dynamo client encounters an error that is worthy of retrying.  This is most useful when "Provisioned Throughput Exceeded" exceptions are encountered when capacity is low in test environments.
 - ``stsRoleARN`` - STS Role ARN to assume before connecting to Dynamo (will use credential settings).  This is typically required if you need to access a different AWS account. Perhaps your ``dev`` and ``production`` aws environments are separated into 2 different accounts.  The ``dev`` account might need to assume a role that is configured within ``production``.
 - ``stsEndpoint`` - Custom endpoint to use for sts (expert)
 - ``stsDuration`` - The duration of STS alternative credentials in seconds.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </licenses>
     
     <properties>
-       <solr.version>5.0.0</solr.version>
+       <solr.version>6.5.0</solr.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </licenses>
     
     <properties>
-       <solr.version>6.5.0</solr.version>
+       <solr.version>6.5.1</solr.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/com/dhi/solr/dataimporthandler/DynamoDataSource.java
+++ b/src/main/java/com/dhi/solr/dataimporthandler/DynamoDataSource.java
@@ -69,6 +69,7 @@ public class DynamoDataSource extends DataSource<Iterator<Map<String, Object>>> 
     public static final String CREDENTIALS_PROFILE_NAME = "credentialProfileName";
     public static final String USE_DEFAULT_PROFILES = "credentialUseProfileDefaults";
     public static final String USE_JAVA_PROPERTIES = "credentialUseJavaProperties";
+    public static final String MAX_ERROR_RETRIES = "maxErrorRetries";
     
     public static final String CONVERT_FIELD_TYPES = CONVERT_TYPE;
     
@@ -82,6 +83,7 @@ public class DynamoDataSource extends DataSource<Iterator<Map<String, Object>>> 
     
     public static final Regions DEFAULT_REGION = Regions.US_EAST_1;
     public static final int CONNECTION_TIMEOUT = 30000;
+    
     
     public static final String ERROR_ACCESS_DENIED = "AccessDeniedException";
 
@@ -217,9 +219,11 @@ public class DynamoDataSource extends DataSource<Iterator<Map<String, Object>>> 
      * 
      * @return 
      */
-    protected ClientConfiguration getAwsClientConfig() {
+    protected ClientConfiguration getAwsClientConfig(int maxErrorRetries) {
         ClientConfiguration clientConfig = new ClientConfiguration();
         clientConfig.setConnectionTimeout(CONNECTION_TIMEOUT);
+        LOG.info("CONFIGURED MAX ERROR RETRIES:" + maxErrorRetries);
+        clientConfig.setMaxErrorRetry(maxErrorRetries);
         return clientConfig;
     }
     
@@ -298,6 +302,7 @@ public class DynamoDataSource extends DataSource<Iterator<Map<String, Object>>> 
         final String profileName = initProps.getProperty(CREDENTIALS_PROFILE_NAME, "");
         final String accessKey = initProps.getProperty(ACCESS_KEY, "");
         final String secretKey = initProps.getProperty(SECRET_KEY, "");
+        final int maxErrorRetries = Integer.parseInt(initProps.getProperty(MAX_ERROR_RETRIES, "10"));
 
         // Get aws credentials based upon the options provided.
         AWSCredentialsProvider credProvider = getAWSCredentials(
@@ -344,7 +349,7 @@ public class DynamoDataSource extends DataSource<Iterator<Map<String, Object>>> 
         
         AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard();
         
-        ClientConfiguration clientConfig = getAwsClientConfig();
+        ClientConfiguration clientConfig = getAwsClientConfig(maxErrorRetries);
         clientBuilder.setClientConfiguration(clientConfig);
         
         if(!dynamoEndpoint.isEmpty()) {

--- a/src/main/java/com/dhi/solr/dataimporthandler/DynamoDataSource.java
+++ b/src/main/java/com/dhi/solr/dataimporthandler/DynamoDataSource.java
@@ -222,7 +222,7 @@ public class DynamoDataSource extends DataSource<Iterator<Map<String, Object>>> 
     protected ClientConfiguration getAwsClientConfig(int maxErrorRetries) {
         ClientConfiguration clientConfig = new ClientConfiguration();
         clientConfig.setConnectionTimeout(CONNECTION_TIMEOUT);
-        LOG.info("CONFIGURED MAX ERROR RETRIES:" + maxErrorRetries);
+        LOG.debug("Configured maxErrorRetries for dynamo client:" + maxErrorRetries);
         clientConfig.setMaxErrorRetry(maxErrorRetries);
         return clientConfig;
     }

--- a/src/test/java/com/dhi/solr/dataimporthandler/DynamoFullImportTest.java
+++ b/src/test/java/com/dhi/solr/dataimporthandler/DynamoFullImportTest.java
@@ -3,11 +3,11 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package com.dhi.solr.dataimporthandler;
+/*package com.dhi.solr.dataimporthandler;
 
-//import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.SolrTestCaseJ4;
 
-//import org.junit.Before;
+import org.junit.Before;*/
 
 /**
  * 
@@ -19,8 +19,13 @@ package com.dhi.solr.dataimporthandler;
     @Override
     @Before
     public void setUp() throws Exception {
-        //super.setUp();
-        //File home = createTempDir("dih-properties").toFile();
-        //System.setProperty("solr.solr.home", home.getAbsolutePath());    
+        super.setUp();
+        File home = createTempDir("dih-properties").toFile();
+        System.setProperty("solr.solr.home", home.getAbsolutePath());    
     }
 }*/
+
+/*
+The test framework for solr expects a certain type or iterator, which the dynamo entity processor is NOT using, so, we will need to figure out how to test that
+this is intended to serve as a starting point for the future of tests. Godspeed.
+*/

--- a/src/test/java/com/dhi/solr/dataimporthandler/DynamoFullImportTest.java
+++ b/src/test/java/com/dhi/solr/dataimporthandler/DynamoFullImportTest.java
@@ -5,22 +5,22 @@
  */
 package com.dhi.solr.dataimporthandler;
 
-import org.apache.solr.SolrTestCaseJ4;
+//import org.apache.solr.SolrTestCaseJ4;
 
-import org.junit.Before;
+//import org.junit.Before;
 
 /**
  * 
  * 
  * @author ben.demott
  */
-public class DynamoFullImportTest extends SolrTestCaseJ4 {
+/*public class DynamoFullImportTest extends SolrTestCaseJ4 {
     
     @Override
     @Before
     public void setUp() throws Exception {
-        super.setUp();
-        File home = createTempDir("dih-properties").toFile();
-        System.setProperty("solr.solr.home", home.getAbsolutePath());    
+        //super.setUp();
+        //File home = createTempDir("dih-properties").toFile();
+        //System.setProperty("solr.solr.home", home.getAbsolutePath());    
     }
-}
+}*/


### PR DESCRIPTION
Made the Max Number of Retries property configurable on the data source portion of the configured data import handler.  I set the default to 10, the data import takes much longer, but, will eventually succeed in retrieving all documents. 